### PR TITLE
chore: update mobile app environment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ pnpm --filter @apex-tradebill/api migrate
 ## Environment Configuration
 
 - Copy `apps/api/.env.example` to `apps/api/.env` and supply database, JWT, and Apex Omni credentials.
-- Copy `apps/mobile/.env.example` to the appropriate `.env.<environment>` file (e.g., `.env.development`). The Expo app reads environment-specific values through `app.config.ts`.
-- Both workspaces respect `EXPO_PUBLIC_*` and `APEX_OMNI_*` variables documented in their respective README files.
+- Copy `apps/mobile/.env.example` to the appropriate `.env.<environment>` file (e.g., `.env.development`). The Expo app only consumes `EXPO_PUBLIC_*` variables; never place private ApeX Omni secrets in mobile env files.
+- The API continues to use `APEX_OMNI_*` for server-side credentials; the mobile app uses `EXPO_PUBLIC_APEX_*` for public endpoints only. See the app-specific READMEs for details.
 
 ## Device Activation Flow
 

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -8,8 +8,8 @@ EXPO_PUBLIC_APP_ENV=development
 EXPO_PUBLIC_API_URL=http://127.0.0.1:4000
 # EXPO_PUBLIC_API_WS_URL=ws://127.0.0.1:4000
 
-# ApeX Omni endpoints (no secrets; API key/secret must stay on the server)
-EXPO_PUBLIC_APEX_ENVIRONMENT=prod # use "testnet" to target the ApeX QA endpoints (falls back to APEX_OMNI_ENVIRONMENT if unset)
+# ApeX Omni endpoints (public only; API key/secret must stay on the server)
+EXPO_PUBLIC_APEX_ENVIRONMENT=prod # use "testnet" to target the ApeX QA endpoints
 
 # The Expo build falls back to the same production/testnet URLs defined for the API service.
 # Uncomment only when you need to point the client at custom infrastructure.

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -16,28 +16,21 @@ corepack pnpm install
 
 ## Environment Configuration
 
-`app.config.ts` loads environment variables from the closest matching file:
-
-1. `.env`
-2. `.env.<environment>`
-3. `.env.local`
-4. `.env.<environment>.local`
-
-Copy the template and adjust values for your profile:
+Expo injects any `EXPO_PUBLIC_*` variables from your `.env*` files into the client bundle. Copy the template and adjust values for your profile:
 
 ```bash
 cp apps/mobile/.env.example apps/mobile/.env.development
 ```
 
-Key variables:
+Key variables (all public):
 
-- `EXPO_PUBLIC_APP_ENV` – `development` | `preview` | `production`; influences which `.env.*` file is read.
+- `EXPO_PUBLIC_APP_ENV` – `development` | `preview` | `production`; used for display/analytics only.
 - `EXPO_PUBLIC_API_URL` – base URL for the TradeBill API (defaults to `http://127.0.0.1:4000`).
 - `EXPO_PUBLIC_API_WS_URL` – optional override for WebSocket connections; falls back to `EXPO_PUBLIC_API_URL`.
-- `EXPO_PUBLIC_APEX_ENVIRONMENT` – `prod` (default) or `testnet`. When unset the mobile build inherits `APEX_OMNI_ENVIRONMENT` from the API env.
-- `EXPO_PUBLIC_APEX_*` – optional overrides for REST/WebSocket endpoints. We default to the same prod/testnet URLs defined for the API service, so only set these when you need an alternate cluster. Credentials stay server-side.
+- `EXPO_PUBLIC_APEX_ENVIRONMENT` – `prod` (default) or `testnet`; chooses which public ApeX endpoints to use.
+- `EXPO_PUBLIC_APEX_*` – optional overrides for REST/WebSocket endpoints. Defaults point to the standard prod/testnet clusters. Do not place private ApeX credentials or any non-public secrets here.
 
-The resolved config is exposed at runtime via `env` (`src/config/env.ts`).
+The resolved config is exposed at runtime via `extra` in `app.config.ts` (see `extra.api` and `extra.apexOmni`).
 
 ## Running the App
 


### PR DESCRIPTION
Isolate mobile app environment configuration to use only `EXPO_PUBLIC_*` variables and remove custom `.env` file parsing.