### PR TITLE
chore: configure mobile build and refine and prevent testnet overrides in production

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -24,6 +24,7 @@ APEX_OMNI_L2_SEED=demo-zk-seed-hex
 APEX_OMNI_ENVIRONMENT=prod
 APEX_OMNI_REST_URL=https://api.pro.apex.exchange
 APEX_OMNI_WS_URL=wss://stream.pro.apex.exchange
+# Testnet endpoints (used only when APEX_OMNI_ENVIRONMENT is set to qa/testnet; ignored in prod)
 APEX_OMNI_TESTNET_REST_URL=https://testnet.omni.apex.exchange/api/
 APEX_OMNI_TESTNET_WS_URL=wss://testnet.omni.apex.exchange/ws/v1
 
@@ -36,4 +37,3 @@ OMNI_BREAKGLASS_PUBLIC_KEY=base64-encoded-public-key
 OMNI_BREAKGLASS_PRIVATE_KEY=base64-encoded-private-key
 OMNI_CACHE_TTL_SECONDS=300
 OMNI_ALLOW_LATEST_VERSION=true # Allow using the "latest" version alias when reading GSM secrets (default true)
-

--- a/apps/api/src/config/__tests__/apexConfig.test.ts
+++ b/apps/api/src/config/__tests__/apexConfig.test.ts
@@ -44,16 +44,19 @@ describe('resolveApeXCredentials', () => {
     expect(resolved?.wsUrl).toBe('wss://testnet.omni.apex.exchange/ws/v1');
   });
 
-  it('infers the testnet environment when dedicated endpoints are provided', () => {
+  it('ignores testnet overrides when environment is production', () => {
     const env = buildEnv({
+      APEX_OMNI_ENVIRONMENT: 'prod',
+      APEX_OMNI_REST_URL: 'https://api.pro.apex.exchange',
+      APEX_OMNI_WS_URL: 'wss://stream.pro.apex.exchange',
       APEX_OMNI_TESTNET_REST_URL: 'https://testnet.omni.apex.exchange/api/',
       APEX_OMNI_TESTNET_WS_URL: 'wss://testnet.omni.apex.exchange/ws/v1',
     });
 
     const resolved = resolveApeXCredentials(env);
-    expect(resolved?.environment).toBe('qa');
-    expect(resolved?.restUrl).toBe('https://testnet.omni.apex.exchange/api/');
-    expect(resolved?.wsUrl).toBe('wss://testnet.omni.apex.exchange/ws/v1');
+    expect(resolved?.environment).toBe('prod');
+    expect(resolved?.restUrl).toBe('https://api.pro.apex.exchange');
+    expect(resolved?.wsUrl).toBe('wss://stream.pro.apex.exchange');
   });
 
   it('falls back to production endpoints when testnet URLs are missing', () => {

--- a/apps/api/src/config/apexConfig.ts
+++ b/apps/api/src/config/apexConfig.ts
@@ -43,27 +43,31 @@ export const resolveApeXCredentials = (
     return null;
   }
 
-  const explicitEnvironment = normalizeEnvironment(env.APEX_OMNI_ENVIRONMENT);
-  const detectedEnvironment =
-    explicitEnvironment === 'prod' &&
-    (Boolean(env.APEX_OMNI_TESTNET_REST_URL) || Boolean(env.APEX_OMNI_TESTNET_WS_URL))
-      ? 'qa'
-      : explicitEnvironment;
+  const environment = normalizeEnvironment(env.APEX_OMNI_ENVIRONMENT);
 
   const restUrl =
-    detectedEnvironment === 'qa'
+    environment === 'qa'
       ? pickFirstDefined(env, ['APEX_OMNI_TESTNET_REST_URL', 'APEX_OMNI_REST_URL'])
       : env.APEX_OMNI_REST_URL;
   const wsUrl =
-    detectedEnvironment === 'qa'
+    environment === 'qa'
       ? pickFirstDefined(env, ['APEX_OMNI_TESTNET_WS_URL', 'APEX_OMNI_WS_URL'])
       : env.APEX_OMNI_WS_URL;
+
+  if (
+    environment === 'prod' &&
+    (env.APEX_OMNI_TESTNET_REST_URL || env.APEX_OMNI_TESTNET_WS_URL)
+  ) {
+    console.warn(
+      'APEX_OMNI_TESTNET_* variables are set but ignored because APEX_OMNI_ENVIRONMENT=prod.',
+    );
+  }
 
   return {
     apiKey,
     apiSecret,
     passphrase: env.APEX_OMNI_API_PASSPHRASE,
-    environment: detectedEnvironment,
+    environment,
     restUrl,
     wsUrl,
     l2Seed: env.APEX_OMNI_L2_SEED,

--- a/apps/api/src/server.secrets.test.ts
+++ b/apps/api/src/server.secrets.test.ts
@@ -71,40 +71,41 @@ describe('Logger Redaction', () => {
 
       const sensitiveData = {
         userData: {
-            jwtSecret: 'super-secret-jwt',
-            breakglassPrivateKey: 'private-key-material',
-            other: 'safe-value'
+          jwtSecret: 'super-secret-jwt',
+          breakglassPrivateKey: 'private-key-material',
+          other: 'safe-value',
         },
         credentials: {
-            apiSecret: 'my-api-secret',
-            passphrase: 'my-passphrase'
+          apiSecret: 'my-api-secret',
+          passphrase: 'my-passphrase',
         },
-        omniBreakglassPrivateKey: 'raw-key'
+        omniBreakglassPrivateKey: 'raw-key',
       };
 
       instance.log.info({ ...sensitiveData }, 'Log with secrets');
 
       expect(loggedMessages.length).toBeGreaterThan(0);
-      const logEntry = loggedMessages[0] as Record<string, any>;
-      
+      const logEntry = loggedMessages[0] as {
+        userData?: {
+          jwtSecret?: unknown;
+          breakglassPrivateKey?: unknown;
+          other?: unknown;
+        };
+        credentials?: {
+          apiSecret?: unknown;
+          passphrase?: unknown;
+        };
+        omniBreakglassPrivateKey?: unknown;
+      };
+
       expect(logEntry.userData).toBeDefined();
-      expect(logEntry.userData.other).toBe('safe-value');
-      
+      expect(logEntry.userData?.other).toBe('safe-value');
+
       // Secrets should be missing
-      expect(logEntry.userData.jwtSecret).toBeUndefined();
-      expect(logEntry.userData.breakglassPrivateKey).toBeUndefined();
-      expect(logEntry.credentials.apiSecret).toBeUndefined();
-      expect(logEntry.credentials.passphrase).toBeUndefined();
-      // Wait, *.credentials.apiSecret means apiSecret INSIDE credentials.
-      // If we use wildcard, it should just remove the leaf.
-      
-      // Let's check specifics based on pino documentation
-      // *.apiSecret should remove apiSecret key anywhere at that level? No, * is one level wildcard.
-      // actually pino redaction syntax: 
-      // 'a.b.c' -> specific path
-      // '*.b.c' -> b.c property of ANY top level property
-      
-      // Checking our expectations against pino behavior.
+      expect(logEntry.userData?.jwtSecret).toBeUndefined();
+      expect(logEntry.userData?.breakglassPrivateKey).toBeUndefined();
+      expect(logEntry.credentials?.apiSecret).toBeUndefined();
+      expect(logEntry.credentials?.passphrase).toBeUndefined();
       expect(logEntry.omniBreakglassPrivateKey).toBeUndefined();
   });
 });

--- a/apps/mobile/.env.production
+++ b/apps/mobile/.env.production
@@ -1,0 +1,12 @@
+# Production defaults for Expo (public only; no secrets)
+EXPO_PUBLIC_APP_ENV=production
+
+# Target the production API preset (Cloud Run default), or override explicitly.
+EXPO_PUBLIC_API_TARGET=prod
+EXPO_PUBLIC_API_URL=https://apex-tradebill-api-prod-224196875744.us-central1.run.app
+EXPO_PUBLIC_API_WS_URL=wss://apex-tradebill-api-prod-224196875744.us-central1.run.app
+
+# Use production ApeX endpoints (no secrets here).
+EXPO_PUBLIC_APEX_ENVIRONMENT=prod
+EXPO_PUBLIC_APEX_REST_URL=https://api.pro.apex.exchange
+EXPO_PUBLIC_APEX_WS_URL=wss://stream.pro.apex.exchange

--- a/apps/mobile/.env.production.example
+++ b/apps/mobile/.env.production.example
@@ -1,0 +1,13 @@
+# Production defaults for Expo (public only; no secrets)
+EXPO_PUBLIC_APP_ENV=production
+
+# Target the production API preset (Cloud Run default), or override explicitly.
+EXPO_PUBLIC_API_TARGET=prod
+# EXPO_PUBLIC_API_PROD_URL=https://apex-tradebill-api-prod-224196875744.us-central1.run.app
+# EXPO_PUBLIC_API_URL=https://your-api.example.com
+# EXPO_PUBLIC_API_WS_URL=wss://your-api.example.com
+
+# Use production ApeX endpoints (no secrets here).
+EXPO_PUBLIC_APEX_ENVIRONMENT=prod
+# EXPO_PUBLIC_APEX_REST_URL=https://api.pro.apex.exchange
+# EXPO_PUBLIC_APEX_WS_URL=wss://stream.pro.apex.exchange

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -2,6 +2,10 @@ import type { ConfigContext, ExpoConfig } from 'expo/config';
 type AppEnvironment = 'development' | 'preview' | 'production';
 type ApexEnvironment = 'prod' | 'qa';
 
+const iosBundleIdentifier =
+  process.env.EXPO_IOS_BUNDLE_IDENTIFIER ?? 'com.apextradebill.mobile';
+const androidPackage = process.env.EXPO_ANDROID_PACKAGE ?? 'com.apextradebill.mobile';
+
 const isAppEnvironment = (value: string | undefined): value is AppEnvironment => {
   if (!value) {
     return false;
@@ -157,8 +161,10 @@ export default ({ config }: ConfigContext = {} as ConfigContext): ExpoConfig => 
     newArchEnabled: true,
     ios: {
       supportsTablet: true,
+      bundleIdentifier: iosBundleIdentifier,
     },
     android: {
+      package: androidPackage,
       adaptiveIcon: {
         backgroundColor: '#E6F4FE',
         foregroundImage: './assets/images/android-icon-foreground.png',
@@ -190,6 +196,9 @@ export default ({ config }: ConfigContext = {} as ConfigContext): ExpoConfig => 
     experiments: {
       typedRoutes: true,
       reactCompiler: true,
+    },
+    runtimeVersion: {
+      policy: 'appVersion',
     },
     extra: {
       environment: appEnv,

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,38 @@
+{
+  "cli": {
+    "version": ">= 14.0.0"
+  },
+  "build": {
+    "development": {
+      "channel": "development",
+      "distribution": "internal",
+      "developmentClient": true,
+      "env": {
+        "EXPO_PUBLIC_APP_ENV": "development",
+        "EXPO_PUBLIC_API_TARGET": "local",
+        "EXPO_PUBLIC_APEX_ENVIRONMENT": "testnet"
+      }
+    },
+    "preview": {
+      "channel": "preview",
+      "distribution": "internal",
+      "env": {
+        "EXPO_PUBLIC_APP_ENV": "preview",
+        "EXPO_PUBLIC_API_TARGET": "prod",
+        "EXPO_PUBLIC_APEX_ENVIRONMENT": "qa"
+      }
+    },
+    "production": {
+      "channel": "production",
+      "autoIncrement": true,
+      "env": {
+        "EXPO_PUBLIC_APP_ENV": "production",
+        "EXPO_PUBLIC_API_TARGET": "prod",
+        "EXPO_PUBLIC_APEX_ENVIRONMENT": "prod"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}


### PR DESCRIPTION
Configure mobile build environments with EAS and refine ApeX environment handling to prevent testnet overrides in production.